### PR TITLE
fix CI failure - database_names() deprecated in pymongo 4.0

### DIFF
--- a/conftrak/server/engine.py
+++ b/conftrak/server/engine.py
@@ -28,7 +28,7 @@ def db_connect(database, mongo_host, mongo_port):
     """
     try:
         client = pymongo.MongoClient(host=mongo_host, port=mongo_port)
-        client.database_names()  # check if the server is really okay.
+        client.list_database_names()  # check if the server is really okay.
     except (pymongo.errors.ConnectionFailure,
             pymongo.errors.ServerSelectionTimeoutError):
         raise ConfTrakException("Unable to connect to MongoDB server...")


### PR DESCRIPTION
CI mongodb-related failures are due to use of deprecated function name database_names() - replaced with list_database_names() 