### PR TITLE
add new function to remove extra keys from UpdateResult.raw_result

### DIFF
--- a/conftrak/server/engine.py
+++ b/conftrak/server/engine.py
@@ -167,7 +167,7 @@ class ConfigurationReferenceHandler(DefaultHandler):
         res = database.configuration.update_many(filter=query,
                                            update={'$set': update},
                                            upsert=False)
-        self.finish(ujson.dumps(res.raw_result))
+        self.finish(ujson.dumps(utils.sanitize_return(res.raw_result)))
 
     @gen.coroutine
     def delete(self):
@@ -186,7 +186,7 @@ class ConfigurationReferenceHandler(DefaultHandler):
         res = database.configuration.update_many(filter={'uid': {'$in': uid_list}},
                                                  update={'$set': {'active': False}},
                                                  upsert=False)
-        self.finish(ujson.dumps(res.raw_result))
+        self.finish(ujson.dumps(utils.sanitize_return(res.raw_result)))
 
 
 class SchemaHandler(DefaultHandler):

--- a/conftrak/server/utils.py
+++ b/conftrak/server/utils.py
@@ -96,3 +96,8 @@ def default_timeuid(document):
     if 'time' not in document or document['time'] is None:
         document['time'] = ttime.time()
     return document
+
+def sanitize_return(result_dict):
+    OLD_KEYS = set(['electionId', 'opTime', '$clusterTime', 'signature', 'operationTime'])
+    cleaned_result_dict = {k: v for k, v in result_dict.items() if k not in OLD_KEYS}
+    return cleaned_result_dict


### PR DESCRIPTION
 * the result from update contains more keys when run on a database
   that has replica sets. remove these extra keys to prevent
   ujson exceptions of being unable to serialize Timestamp() objects