### PR TITLE
Update version requirement

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         dependencies: ["pip", "conda"]
       fail-fast: false
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,8 @@ jobs:
         if: matrix.dependencies == 'conda'
         run: |
           set -vxeo pipefail
-          conda install -y -c conda-forge doct jsonschema mock mongomock pymongo pytest pyyaml requests tornado ujson
+          conda install -y -c conda-forge doct jsonschema mock pymongo pytest pyyaml requests tornado ujson
+          pip install mongomock
 
       - name: Install the package
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 mock
-mongomock>=4.2.0
+mongomock
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 mock
-mongomock
+mongomock>=4.2.0
 pytest

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setuptools.setup(
     classifiers=[
         "License :: OSI Approved :: BSD License",
         "Development Status :: 3 - Alpha",
-        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
-min_version = (3, 6)
+min_version = (3, 8)
 if sys.version_info < min_version:
     error = """
 mxtools does not support Python {0}.{1}.
@@ -52,6 +52,11 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     entry_points={"console_scripts": ["conftrak_startup = conftrak.startup:start_server"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,10 @@ import versioneer
 import os
 import sys
 
-# NOTE: This file must remain Python 2 compatible for the foreseeable future,
-# to ensure that we error out properly for people with outdated setuptools
-# and/or pip.
 min_version = (3, 8)
 if sys.version_info < min_version:
     error = """
-mxtools does not support Python {0}.{1}.
+conftrak does not support Python {0}.{1}.
 Python {2}.{3} and above is required. Check your Python version like so:
 
 python3 --version


### PR DESCRIPTION
- after mongomock python version requirement being imposed, reflect this in contrak
- now works with python 3.8 and newer